### PR TITLE
Add removeSection() method to remove a whole section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## in progress
+## 1.3.0 (in progress)
 
 + Added tests for php 7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.3.0 (in progress)
-
-+ Added tests for php 7.3
-
 ## 1.2.0 (30. April 2019)
+
 + Added feature for whole section removal
++ Added tests for php 7.3
 
 ## 1.1.0 (21. December 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 + Added tests for php 7.3
 
+## 1.2.0 (30. April 2019)
++ Added feature for whole section removal
+
 ## 1.1.0 (21. December 2018)
 
 + Add version constraint compare function.

--- a/src/ComposerReader.php
+++ b/src/ComposerReader.php
@@ -134,6 +134,20 @@ class ComposerReader implements ComposerReaderInterface
         
         $this->_content = $content;
     }
+        
+    /**
+     * @inheritdoc
+     */
+    public function removeSection($section)
+    {
+        $content = $this->getContent();
+        
+        if(isset($content[$section])) {
+            unset ($content[$section]);
+        }
+        
+        $this->_content = $content;
+    }
     
     /**
      * Run a composer command in the given composer.json.

--- a/src/ComposerReaderInterface.php
+++ b/src/ComposerReaderInterface.php
@@ -34,6 +34,7 @@ interface ComposerReaderInterface
      * This will remove the whole section!
      *
      * @param string $section
+     * @since 1.2.0
      */
     public function removeSection($section);
     

--- a/src/ComposerReaderInterface.php
+++ b/src/ComposerReaderInterface.php
@@ -29,6 +29,15 @@ interface ComposerReaderInterface
     public function updateSection($section, $data);
     
     /**
+     * Remove a given section.
+     *
+     * This will remove the whole section!
+     *
+     * @param string $section
+     */
+    public function removeSection($section);
+    
+    /**
      * Save the current Data.
      *
      * Saves the current json data into the composer.json of the given reader.

--- a/tests/ComposerReaderTest.php
+++ b/tests/ComposerReaderTest.php
@@ -106,4 +106,13 @@ class ComposerReaderTest extends ComposerReaderTestCase
         
         $this->assertTrue($r);
     }
+    
+    public function testRemove()
+    {
+        $reader = new ComposerReader($this->getValidJson());
+
+        $reader->removeSection('autoload');
+
+        $this->assertArrayNotHasKey('autoload', $reader->getContent());
+    }
 }


### PR DESCRIPTION
When an autoload section for instance contains one single entry and you remove it, the save() will generate a non valid composer file with an empty autoload section. 
This will trigger an error with composer dump-autoload

```
  [Composer\Json\JsonValidationException]
  "./composer.json" does not match the expected JSON schema:
   - autoload.psr-4 : Array value found, but an object is required

```

Adding the removeSection() will allow to remove such empty section using this library.